### PR TITLE
add defaults for running without config.yaml

### DIFF
--- a/argo/headless/headless.go
+++ b/argo/headless/headless.go
@@ -141,7 +141,6 @@ func testAPI(ctx context.Context, clientOpts *apiclient.ClientOptions) error {
 // StartLocalServer allows executing command in a headless mode: on the fly starts Argo CD API server and
 // changes provided client options to use started API server port
 func StartLocalServer(ctx context.Context, clientOpts *apiclient.ClientOptions, ctxStr string, port *int, address *string) error {
-	fmt.Printf("clientOpts: %+v\n", clientOpts)
 	flags := pflag.NewFlagSet("tmp", pflag.ContinueOnError)
 	clientConfig := cli.AddKubectlFlagsToSet(flags)
 	startInProcessAPI := clientOpts.Core

--- a/argo/headless/headless.go
+++ b/argo/headless/headless.go
@@ -141,6 +141,7 @@ func testAPI(ctx context.Context, clientOpts *apiclient.ClientOptions) error {
 // StartLocalServer allows executing command in a headless mode: on the fly starts Argo CD API server and
 // changes provided client options to use started API server port
 func StartLocalServer(ctx context.Context, clientOpts *apiclient.ClientOptions, ctxStr string, port *int, address *string) error {
+	fmt.Printf("clientOpts: %+v\n", clientOpts)
 	flags := pflag.NewFlagSet("tmp", pflag.ContinueOnError)
 	clientConfig := cli.AddKubectlFlagsToSet(flags)
 	startInProcessAPI := clientOpts.Core

--- a/cobra/cmd/root.go
+++ b/cobra/cmd/root.go
@@ -28,7 +28,12 @@ var cfgContext string
 // Cluster gets set to current kubeconfig context if using core, otherwise it's set to config-context
 var Cluster string
 
-var argocdClientOptions = apiclient.ClientOptions{}
+var argocdClientOptions = apiclient.ClientOptions{
+	ServerAddr:  "kubernetes",
+	Core:        true,
+	PlainText:   true,
+	PortForward: false,
+}
 
 var sessionRequest = session.SessionCreateRequest{}
 
@@ -218,5 +223,16 @@ func initConfig() {
 				sessionRequest.Password = password
 			}
 		}
+	} else {
+		// set KubeOverrides namespace to 'argocd'
+		context := clientcmdapi.Context{
+			Namespace: "argocd",
+		}
+		configOverrides := clientcmd.ConfigOverrides{
+			Context: context,
+		}
+		argocdClientOptions.KubeOverrides = &configOverrides
+		// use current kubeconfig contxt as cluster name
+		Cluster = config.CurrentContext
 	}
 }


### PR DESCRIPTION
Set default settings on startup if no config.yaml file is present/specified. 

ClientOptions:

```
ServerAddr:  "kubernetes",
Core:        true,
PlainText:   true,
PortForward: false,
```

ArgoCD namespace: `argocd`. 
Cluster name: current kubernetes context name

